### PR TITLE
Build with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+
+cmake_minimum_required (VERSION 3.13)
+
+project (compilium
+         LANGUAGES C)
+
+enable_testing ()
+
+function (setvar_default var_)
+    if (NOT DEFINED ${var_})
+        set (${var_} ${ARGN} PARENT_SCOPE)
+    endif ()
+endfunction ()
+
+setvar_default (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+setvar_default (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+setvar_default (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+set (HEADERS compilium.h)
+set (SOURCES ast.c type.c parser.c compilium.c)
+
+set (COMPILER_NAME compilium)
+
+add_executable (${COMPILER_NAME} ${SOURCES} ${HEADERS})
+target_compile_features (${COMPILER_NAME} PRIVATE c_std_11)
+foreach (w_ IN ITEMS all pedantic extra conditional-uninitialized)
+    target_compile_options (${COMPILER_NAME} PRIVATE -W${w_})
+endforeach ()
+foreach (s_ IN ITEMS address undefined)
+    target_compile_options (${COMPILER_NAME} PRIVATE -fsanitize=${s_})
+    target_link_options (${COMPILER_NAME} PRIVATE -fsanitize=${s_})
+endforeach ()
+
+add_test (NAME list-test
+          COMMAND ${COMPILER_NAME} --run-unittest=List)
+
+add_test (NAME type-test
+          COMMAND ${COMPILER_NAME} --run-unittest=Type)
+
+add_test (NAME all-test
+          COMMAND env COMPILER_BINARY=$<TARGET_FILE:${COMPILER_NAME}> HOST_CC=${CMAKE_C_COMPILER} ./test.sh
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CFLAGS=-Wall -Wpedantic -Wextra -Wconditional-uninitialized -std=c11
+SANITIZERS=-fsanitize=address -fsanitize=undefined
 SRCS=ast.c compilium.c parser.c type.c
 HEADERS=compilium.h
 CC=clang
@@ -7,10 +8,10 @@ LLDB_ARGS = -o 'settings set interpreter.prompt-on-quit false' \
 			-o 'process launch'
 
 compilium : $(SRCS) $(HEADERS) Makefile
-	$(CC) $(CFLAGS) -o $@ $(SRCS) 
+	$(CC) $(CFLAGS) $(SANITIZERS) -o $@ $(SRCS)
 
 compilium_dbg : $(SRCS) $(HEADERS) Makefile
-	$(CC) $(CFLAGS) -g -o $@ $(SRCS)
+	$(CC) $(CFLAGS) $(SANITIZERS) -g -o $@ $(SRCS)
 
 debug : compilium_dbg failcase.c
 	lldb $(LLDB_ARGS)\

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![CircleCI](https://circleci.com/gh/hikalium/compilium/tree/v2.svg?style=svg)](https://circleci.com/gh/hikalium/compilium/tree/v2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[WIP] C compiler + hikalium
+\[WIP\] C compiler + hikalium
 
 ## Build
 ```
@@ -12,6 +12,13 @@ make
 ## Test
 ```
 make testall
+```
+
+## Configure/Build with [CMake](https://cmake.org)
+```bash
+mkdir BUILD; cd BUILD
+cmake ..
+make
 ```
 
 ## License

--- a/compilium.c
+++ b/compilium.c
@@ -812,4 +812,5 @@ int main(int argc, char *argv[]) {
     PrintTokenStrToFile(n->op, stdout);
     putchar('\n');
   }
+  return 0;
 }

--- a/compilium.h
+++ b/compilium.h
@@ -135,7 +135,7 @@ void PrintTokenStrToFile(struct Node *t, FILE *fp);
 void PrintASTNode(struct Node *n);
 
 // @parser.c
-struct Node *Parse();
+struct Node *Parse(struct Node *passed_tokens);
 
 // tokenizer.c
 struct Node *CreateToken(const char *input);

--- a/test.sh
+++ b/test.sh
@@ -1,16 +1,19 @@
 #!/bin/bash -e
 
+compilium=${COMPILER_BINARY:-./compilium}
+host_cc=${HOST_CC:-cc}
+target_os=$(uname)
 function test_result {
   input="$1"
   expected="$2"
   expected_stdout="$3"
   testname="$4"
   printf "$expected_stdout" > expected.stdout
-  ./compilium --target-os `uname` "$input" > out.S || { \
+  ${compilium} --target-os ${target_os} "$input" > out.S || { \
     echo "$input" > failcase.c; \
     echo "Compilation failed."; \
     exit 1; }
-  gcc out.S
+  ${host_cc} out.S
   actual=0
   ./a.out > out.stdout || actual=$?
   if [ $expected = $actual ]; then
@@ -18,7 +21,7 @@ function test_result {
         && echo "PASS $testname returns $expected" \
         || { echo "FAIL $testname: stdout diff"; exit 1; }
   else
-    echo "FAIL $testname: expected $expected but got $actual"; echo $input > failcase.c; exit 1; 
+    echo "FAIL $testname: expected $expected but got $actual"; echo $input > failcase.c; exit 1;
   fi
 }
 


### PR DESCRIPTION
 - To utilize [CLion](https://www.jetbrains.com/clion/)'s feature, `CMakeLists.txt` is needed.
